### PR TITLE
Implement redirect API route

### DIFF
--- a/src/app/api/url-redirect/[slug]/route.ts
+++ b/src/app/api/url-redirect/[slug]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { urlFromServer } from "@/server/middleware/redirect";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { slug: string } },
+) {
+  const result = await urlFromServer(params.slug);
+
+  if (result.error) {
+    return NextResponse.json(result, { status: 500 });
+  }
+
+  return NextResponse.json(result);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,7 +12,7 @@ import {
   publicRoutes,
 } from "./routes";
 
-import { urlFromServer } from "./server/middleware/redirect";
+import type { urlFromServerResult } from "./server/middleware/redirect";
 
 const { auth } = NextAuth(authConfig);
 
@@ -66,7 +66,12 @@ export default auth(async (req) => {
   // ⚙️ Redirect using slug:
   // If not public route and not protected route:
   if (!isPublicRoute && !isProtectedRoute && !isCheckRoute) {
-    const getDataApi = await urlFromServer(slugRoute!);
+    const apiUrl = new URL(`/api/url-redirect/${slugRoute}`, nextUrl);
+    const res = await fetch(apiUrl);
+    if (!res.ok) {
+      return NextResponse.json({ error: "Failed to fetch" }, { status: res.status });
+    }
+    const getDataApi = (await res.json()) as urlFromServerResult;
 
     if (getDataApi.redirect404) {
       console.log("🚧 Error - Redirect 404: ", slugRoute);


### PR DESCRIPTION
## Summary
- add `url-redirect/[slug]` API route
- call API route in `middleware.ts` instead of server util

## Testing
- `pnpm lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6851a9fd50b48330b62caf61aad2d377